### PR TITLE
Removed @javascript on beforeScenario

### DIFF
--- a/src/Context/ParagraphsContext.php
+++ b/src/Context/ParagraphsContext.php
@@ -23,7 +23,7 @@ class ParagraphsContext implements Context {
   protected $paragraphNames = [];
 
   /**
-   * @BeforeScenario @javascript
+   * @BeforeScenario
    * Wrap XMLHttpRequest
    */
   public function prepare(BeforeScenarioScope $scope) {


### PR DESCRIPTION
`@javascript` prevents the beforeScenario method from running on non-javascript based tests. Which causes the error in https://github.com/miiimooo/behat-tools/issues/2