### PR TITLE
Add support for paragraph before/after events.

### DIFF
--- a/src/Context/Annotation/Reader.php
+++ b/src/Context/Annotation/Reader.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace miiimooo\BehatTools\Context\Annotation;
+
+use Behat\Behat\Context\Annotation\AnnotationReader;
+use Drupal\DrupalExtension\Hook\Dispatcher;
+use ReflectionMethod;
+
+/**
+ * Annotated contexts reader.
+ *
+ * @see \Behat\Behat\Context\Loader\AnnotatedLoader
+ */
+class Reader implements AnnotationReader
+{
+
+  /**
+   * @var string
+   */
+    private static $regex = '/^\@(beforeparagraphcreate|afterparagraphcreate)(?:\s+(.+))?$/i';
+
+  /**
+   * @var string[]
+   */
+    private static $classes = array(
+      'beforeparagraphcreate' => 'miiimooo\BehatTools\Hook\Call\BeforeParagraphCreate',
+      'afterparagraphcreate' => 'miiimooo\BehatTools\Hook\Call\AfterParagraphCreate',
+    );
+
+  /**
+   * {@inheritDoc}
+   */
+    public function readCallee($contextClass, ReflectionMethod $method, $docLine, $description)
+    {
+
+        if (!preg_match(self::$regex, $docLine, $match)) {
+            return null;
+        }
+
+        $type = strtolower($match[1]);
+        $class = self::$classes[$type];
+        $pattern = isset($match[2]) ? $match[2] : null;
+        $callable = array($contextClass, $method->getName());
+
+        return new $class($pattern, $callable, $description);
+    }
+}

--- a/src/Hook/Call/AfterParagraphCreate.php
+++ b/src/Hook/Call/AfterParagraphCreate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace miiimooo\BehatTools\Hook\Call;
+
+use Drupal\DrupalExtension\Hook\Call\EntityHook;
+use miiimooo\BehatTools\Hook\Scope\ParagraphScope;
+
+/**
+ * AfterParagraphCreate hook class.
+ */
+class AfterParagraphCreate extends EntityHook
+{
+
+  /**
+   * Initializes hook.
+   */
+    public function __construct($filterString, $callable, $description = null)
+    {
+        parent::__construct(ParagraphScope::AFTER, $filterString, $callable, $description);
+    }
+
+  /**
+   * {@inheritdoc}
+   */
+    public function getName()
+    {
+        return 'AfterParagraphCreate';
+    }
+}

--- a/src/Hook/Call/BeforeParagraphCreate.php
+++ b/src/Hook/Call/BeforeParagraphCreate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace miiimooo\BehatTools\Hook\Call;
+
+use Drupal\DrupalExtension\Hook\Call\EntityHook;
+use miiimooo\BehatTools\Hook\Scope\ParagraphScope;
+
+/**
+ * BeforeParagraphCreate hook class.
+ */
+class BeforeParagraphCreate extends EntityHook
+{
+
+  /**
+   * Initializes hook.
+   */
+    public function __construct($filterString, $callable, $description = null)
+    {
+        parent::__construct(ParagraphScope::BEFORE, $filterString, $callable, $description);
+    }
+
+  /**
+   * {@inheritdoc}
+   */
+    public function getName()
+    {
+        return 'BeforeParagraphCreate';
+    }
+}

--- a/src/Hook/Scope/AfterParagraphCreateScope.php
+++ b/src/Hook/Scope/AfterParagraphCreateScope.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Entity scope.
+ */
+namespace miiimooo\BehatTools\Hook\Scope;
+
+use Behat\Testwork\Hook\Scope\HookScope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class AfterParagraphCreateScope extends ParagraphScope
+{
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+    public function getName()
+    {
+        return self::AFTER;
+    }
+}

--- a/src/Hook/Scope/BeforeParagraphCreateScope.php
+++ b/src/Hook/Scope/BeforeParagraphCreateScope.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Entity scope.
+ */
+namespace miiimooo\BehatTools\Hook\Scope;
+
+use Behat\Testwork\Hook\Scope\HookScope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class BeforeParagraphCreateScope extends ParagraphScope
+{
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+    public function getName()
+    {
+        return self::BEFORE;
+    }
+}

--- a/src/Hook/Scope/ParagraphScope.php
+++ b/src/Hook/Scope/ParagraphScope.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @file
+ * Paragraph scope.
+ */
+namespace miiimooo\BehatTools\Hook\Scope;
+
+use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+use Behat\Behat\Context\Context;
+use Behat\Testwork\Hook\Scope\HookScope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+abstract class ParagraphScope extends BaseEntityScope
+{
+
+    const BEFORE = 'paragraph.create.before';
+    const AFTER = 'paragraph.create.after';
+}

--- a/src/MiiimoooExtension/ServiceContainer/MiiimoooExtension.php
+++ b/src/MiiimoooExtension/ServiceContainer/MiiimoooExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace miiimooo\BehatTools\MiiimoooExtension\ServiceContainer;
+
+use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Testwork\ServiceContainer\ServiceProcessor;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\FileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+class MiiimoooExtension implements ExtensionInterface
+{
+
+  /**
+   * Extension configuration ID.
+   */
+    const CONFIG_ID = 'miiimooo';
+
+  /**
+   * Initializes compiler pass.
+   *
+   * @param null|ServiceProcessor $processor
+   */
+    public function __construct(ServiceProcessor $processor = null)
+    {
+    }
+
+  /**
+   * {@inheritDoc}
+   */
+    public function getConfigKey()
+    {
+        return self::CONFIG_ID;
+    }
+
+  /**
+   * {@inheritDoc}
+   */
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+  /**
+   * {@inheritDoc}
+   */
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/config'));
+        $loader->load('services.yml');
+    }
+
+  /**
+   * {@inheritDoc}
+   */
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+  /**
+   * {@inheritDoc}
+   */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+
+}

--- a/src/MiiimoooExtension/ServiceContainer/config/services.yml
+++ b/src/MiiimoooExtension/ServiceContainer/config/services.yml
@@ -1,0 +1,11 @@
+parameters:
+  # Hook loader.
+  miiimooo.behattools.context.annotation.reader.class: miiimooo\BehatTools\Context\Annotation\Reader
+
+services:
+  miiomooo.behattools.context.loader.annotated:
+    class: "%miiimooo.behattools.context.annotation.reader.class%"
+    arguments:
+    tags:
+      - { name: context.annotation_reader }
+


### PR DESCRIPTION
Implements before/after events similar to what nodes/users/term have which can be hooked with a @BeforeParagraphCreate or @AfterParagraphCreate annotation in your own contexts.

Enable the new extension in behat.yml:
```
extensions:
  miiimooo\BehatTools\MiiimoooExtension: ~
```