### PR TITLE
Update dependency to sabre/dav

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.5",
         "behat/behat": "^3.0.13",
         "behat/mink-extension": "^2.3.1",
-        "sabre/dav": "^3.2"
+        "sabre/dav": "^3.2 || ^4.4.0"
     },
     "require-dev": {
         "behat/mink-goutte-driver": "^1.1"


### PR DESCRIPTION
The `sabre/dav` dependency blocks the Drupal 10 due to its dependency on `psr/log`.

This PR allows the existing version or  `4.4.0` (current stable release) thru 5.

I've reviewed the project's usage of `sabre/dav` and it's only in `\miiimooo\BehatTools\Context\DavScreenshotFailureContext::storeDumps` for uploading screenshots. I have not attempted to test this functionality, but I have reviewed the interfaces involved and it seems compatible (no pertinent changes).